### PR TITLE
Change candidate urls implementation from list to asyncio queue and little fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class MySpider(Spider):
 MySpider.run()
 ```
 
-Or use XpathParser:
+Or use XPathParser:
 
 ```python
 from gain import Css, Item, Parser, XPathParser, Spider

--- a/gain/item.py
+++ b/gain/item.py
@@ -53,3 +53,6 @@ class Item(metaclass=ItemType):
             await self.__result__.save(self.results)
         else:
             raise NotImplementedError
+
+    def __repr__(self):
+        return '<item {}>'.format(self.results)

--- a/gain/spider.py
+++ b/gain/spider.py
@@ -30,7 +30,7 @@ class Spider:
     def is_running(cls):
         is_running = False
         for parser in cls.parsers:
-            if len(parser.pre_parse_urls) > 0 or len(parser.parsing_urls) > 0:
+            if not parser.pre_parse_urls.empty() or len(parser.parsing_urls) > 0:
                 is_running = True
         return is_running
 


### PR DESCRIPTION
The original URL schedule was implemented by a list named 'pre_parse_urls'. Then getting URL is a LIFO way so that item parsing will wait until all entry pages are parsed. It's not proper in a crawler.
My change is to use a queue with FIFO order.  The plus is that we can refactor the framework into distributed style in future.
