### PR TITLE
Queue timeout and python 3.6 support.

### DIFF
--- a/gain/parser.py
+++ b/gain/parser.py
@@ -66,7 +66,7 @@ class BaseParser(object):
             logger.info('Followed({}/{}): {}'.format(len(self.done_urls), len(self.filter_urls), url))
 
     async def task(self, spider, semaphore):
-        with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(cookie_jar=spider.cookie_jar) as session:
             while spider.is_running():
                 url = await self.pre_parse_urls.get()
                 self.parsing_urls.append(url)

--- a/gain/parser.py
+++ b/gain/parser.py
@@ -68,9 +68,12 @@ class BaseParser(object):
     async def task(self, spider, semaphore):
         async with aiohttp.ClientSession(cookie_jar=spider.cookie_jar) as session:
             while spider.is_running():
-                url = await self.pre_parse_urls.get()
-                self.parsing_urls.append(url)
-                asyncio.ensure_future(self.execute_url(url, spider, session, semaphore))
+                try:
+                    url = await asyncio.wait_for(self.pre_parse_urls.get(), 5)
+                    self.parsing_urls.append(url)
+                    asyncio.ensure_future(self.execute_url(url, spider, session, semaphore))
+                except asyncio.TimeoutError:
+                    pass
 
 
 class Parser(BaseParser):

--- a/gain/spider.py
+++ b/gain/spider.py
@@ -25,6 +25,7 @@ class Spider:
     interval = None #Todo: Limit the interval between two requests
     headers = {}
     proxy = None
+    cookie_jar = None
 
     @classmethod
     def is_running(cls):
@@ -70,6 +71,6 @@ class Spider:
 
     @classmethod
     async def init_parse(cls, semaphore):
-        with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(cookie_jar=cls.cookie_jar) as session:
             html = await fetch(cls.start_url, cls, session, semaphore)
             cls.parse(html)


### PR DESCRIPTION
There're two commits
First of all, we have to pass some checks, and bring the sessions to the subsequent requests. Therefore, I suggest that we can take cookie_jar to manipulate sessions.

Secondly, there's a bug, and happen to block while dequing.
Since, the condition at "spider.is_running()" has a chance that queue is empty but len(parser.parsing_urls) > 0. Indeed, there's another possibility that new urls would enqueue somehow; nevertheless, if there's no other new url, the event_loop won't stop unless you interrupt it.

I try to impose the timeout mechanism for it. By default, we will wait for 5 secs until new urls arrive; otherwise, it would cause timeout.